### PR TITLE
Excludes keywords and publisher notes from the chapter form.

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -101,7 +101,7 @@ class ChapterForm(forms.ModelForm):
 
     class Meta:
         model = models.Chapter
-        exclude = ('book', 'filename')
+        exclude = ('book', 'filename', 'keywords', 'publisher_notes')
 
     def save(self, commit=True, book=None, *args, **kwargs):
         save_chapter = super(ChapterForm, self).save(commit=False)


### PR DESCRIPTION
These fields were added but not handled properly on the ChapterForm. It will need some reworking, in the short term we should exclude them from teh form.